### PR TITLE
fix build

### DIFF
--- a/NewModLauncher/NewModLauncher.csproj
+++ b/NewModLauncher/NewModLauncher.csproj
@@ -6,7 +6,6 @@
     <ApplicationIcon>Assets/nm.ico</ApplicationIcon>
     <Nullable>enable</Nullable>
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
-    <ApplicationManifest>app.manifest</ApplicationManifest>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
   </PropertyGroup>
 


### PR DESCRIPTION
Fixes building for linux and windows. 

Previously, `dotnet build` would fail with `CSC : error CS1926: Error opening Win32 manifest file /home/user/NewModLauncher/NewModLauncher/app.manifest -- Could not find file '/home/user/NewModLauncher/NewModLauncher/app.manifest'.`

now `dotnet build` (for windows and linux) just gives a few warnings, I didn't address those in this pr tho.